### PR TITLE
Urgent: Fix renovate configuration error

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
         "tekton",
         "dockerfile",
         "custom.regex",
-        "rpm",
+        "rpm-lockfile",
         "github-actions"
     ],
     "automerge": true,


### PR DESCRIPTION
This is badly needed in order to merge #105 
We need to restore the automatic RPM updates to get the newest rust version to be able to build the new limitador image