### PR TITLE
fix: add openssl-libs to runtime stage for FIPS compliance

### DIFF
--- a/Containerfile.limitador
+++ b/Containerfile.limitador
@@ -51,8 +51,8 @@
           io.openshift.tags="rate limiting, envoy, api" \
           maintainer="asnaps@redhat.com"
 
-    # shadow-utils is required for `useradd`
-    RUN PKGS="libgcc libstdc++ shadow-utils" \
+    # shadow-utils is required for `useradd`; openssl-libs required for FIPS (dynamic libcrypto.so)
+    RUN PKGS="libgcc libstdc++ shadow-utils openssl-libs" \
         && microdnf --assumeyes install --nodocs $PKGS \
         && rpm --verify --nogroup --nouser $PKGS \
         && microdnf --assumeyes clean all


### PR DESCRIPTION
## Summary

Add `openssl-libs` to the runtime stage package install so `libcrypto.so` is present when the container starts.

## Context

The upstream limitador-server recently switched from vendoring OpenSSL (compiling it statically into the binary) to dynamically linking against the system `libcrypto.so`. This was done in https://github.com/Kuadrant/limitador/pull/504 to enable FIPS compliance on RHEL 9 — when the host kernel has FIPS mode enabled, the system `libcrypto.so` (CMVP #4746) activates FIPS automatically, but only if the binary actually uses it rather than a vendored copy.

Without `openssl-libs` in the runtime image, the limitador-server process will fail to start with:
```
error while loading shared libraries: libcrypto.so.3: cannot open shared object file
```

## Review

Single line change in the runtime stage `microdnf install` — adds `openssl-libs` alongside the existing `libgcc`, `libstdc++`, and `shadow-utils` packages.

## Test plan

- [ ] Konflux PR build passes
- [ ] limitador-server starts successfully on a FIPS-enabled cluster with `libcrypto.so` present in `/proc/1/maps`