### PR TITLE
fix: force dynamic OpenSSL linkage for FIPS compliance

### DIFF
--- a/Containerfile.limitador
+++ b/Containerfile.limitador
@@ -14,6 +14,7 @@
     ARG CARGO_ARGS
     ENV GITHUB_SHA=${GITHUB_SHA:-unknown}
     ENV RUSTFLAGS="-C target-feature=-crt-static"
+    ENV OPENSSL_NO_VENDOR=1
 
     # We set the env here just to make sure that the build is invalidated if the args change
     ENV CARGO_ARGS=${CARGO_ARGS}


### PR DESCRIPTION
## Problem

The Rust `openssl` crate by default statically bundles its own OpenSSL rather than linking against the system OpenSSL. This means the limitador binary uses a non-FIPS-validated bundled OpenSSL even on FIPS-enabled RHEL nodes.

Verified: `ldd /usr/local/bin/limitador-server` shows no `libcrypto` without this fix.

## Fix

Add `OPENSSL_NO_VENDOR=1` to the build stage. This forces the Rust `openssl` crate to dynamically link against the system `libcrypto.so.3` provided by RHEL, which is the FIPS-validated OpenSSL (CMVP #4746).

## Verification

Built test image `quay.io/pstefans/limitador-fips-test:latest` with this flag and deployed to a FIPS-enabled OpenShift cluster.

`ldd /usr/local/bin/limitador-server` confirms:
```
libssl.so.3 => /lib64/libssl.so.3
libcrypto.so.3 => /lib64/libcrypto.so.3
```

Pod ran with 0 restarts on the FIPS cluster.