### PR TITLE
Update prefetch-dependencies task

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -59,7 +59,7 @@ spec:
       - name: name
         value: prefetch-dependencies-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.7.1@sha256:8ca8782a577540eaf9e0190063846960bd1bd6066d49e8b86bfde83dae108a0d
+        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.10.2@sha256:9214cb1d568a96bf5d605daac34f3b713325e1756724b64ac1ff2cb554e4d2f3
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
Replaces old task-prefetch-dependencies-oci-ta refs below 0.8 with quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.10.2@sha256:9214cb1d568a96bf5d605daac34f3b713325e1756724b64ac1ff2cb554e4d2f3.\n\nOnly the prefetch-dependencies task reference is changed.