### PR TITLE
Migrate Tekton config to RHCL 1.5 stream

### DIFF
--- a/.tekton/rhcl-1-5-limitador-pull-request.yaml
+++ b/.tekton/rhcl-1-5-limitador-pull-request.yaml
@@ -8,13 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "rhcl-1.4"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "rhcl-1.5"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: rhcl-1-4-limitador-operator
-    appstudio.openshift.io/component: rhcl-1-4-limitador-operator
+    appstudio.openshift.io/application: rhcl-1-5-limitador-operator
+    appstudio.openshift.io/component: rhcl-1-5-limitador-operator
     pipelines.appstudio.openshift.io/type: build
-  name: rhcl-1-4-limitador-on-pull-request
+  name: rhcl-1-5-limitador-on-pull-request
   namespace: api-management-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-limitador:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-5-limitador:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
@@ -33,7 +33,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:	
-    serviceAccountName: build-pipeline-rhcl-1-4-limitador
+    serviceAccountName: build-pipeline-rhcl-1-5-limitador
   workspaces:	
   - name: git-auth	
     secret:	

--- a/.tekton/rhcl-1-5-limitador-push.yaml
+++ b/.tekton/rhcl-1-5-limitador-push.yaml
@@ -7,13 +7,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhcl-1.4"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rhcl-1.5"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: rhcl-1-4-limitador-operator
-    appstudio.openshift.io/component: rhcl-1-4-limitador
+    appstudio.openshift.io/application: rhcl-1-5-limitador-operator
+    appstudio.openshift.io/component: rhcl-1-5-limitador
     pipelines.appstudio.openshift.io/type: build
-  name: rhcl-1-4-limitador-on-push
+  name: rhcl-1-5-limitador-on-push
   namespace: api-management-tenant
 spec:
   params:
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-limitador:{{revision}}
+    value: quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-5-limitador:{{revision}}
   - name: dockerfile
     value: Containerfile.limitador
   - name: prefetch-input
@@ -30,7 +30,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:	
-    serviceAccountName: build-pipeline-rhcl-1-4-limitador	
+    serviceAccountName: build-pipeline-rhcl-1-5-limitador	
   workspaces:	
   - name: git-auth	
     secret:	


### PR DESCRIPTION
Rename the limitador Tekton pipeline files from `rhcl-1-4` to `rhcl-1-5` and update their internal references (target branch, application/component labels, output images, service account, and self-referencing paths) to match the new RHCL 1.5 stream.

The `multi-arch-build-pipeline.yaml` was intentionally left untouched, and there are no 1.4.x version references to bump in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)